### PR TITLE
Add compose stacks per category and setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,11 @@
 # Helen
-A home server and Calendar app
+A home server and Calendar app.
 
-🔧 How to Use It
-Save the file as docker-compose.yml
+## Usage
+Docker compose files are organized by service category in their own directories. Run `./setup_services.py` to start all stacks.
 
-Run the stack:
+Access Nginx Proxy Manager at `http://<your-ip>:81` with the default login `admin@example.com` / `changeme` (you will be prompted to reset the password).
 
---bash
-Copy
-Edit
-podman-compose -p Helen-Infrastructure up -d
---bash
-Access Nginx Proxy Manager at:
-
-http://<your-ip>:81
-
-Default login: admin@example.com / changeme (prompted to reset on first login)
 
 🏗️ Infrastructure
 These are the foundational containers that support and enable other services.

--- a/ai_llm/docker-compose.yml
+++ b/ai_llm/docker-compose.yml
@@ -1,0 +1,95 @@
+version: "3.8"
+
+services:
+  ollama:
+    image: ollama/ollama
+    container_name: ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    restart: unless-stopped
+
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    container_name: open-webui
+    ports:
+      - "3000:3000"
+    environment:
+      - OLLAMA_API_BASE_URL=http://ollama:11434
+    volumes:
+      - openwebui_data:/app/backend/data
+    depends_on:
+      - ollama
+    restart: unless-stopped
+
+  textgen-webui:
+    image: ghcr.io/oobabooga/text-generation-webui:latest
+    container_name: textgen-webui
+    ports:
+      - "7860:7860"
+    volumes:
+      - textgen_data:/app
+    restart: unless-stopped
+
+  jupyter:
+    image: jupyter/base-notebook
+    container_name: jupyter
+    ports:
+      - "8888:8888"
+    volumes:
+      - jupyter_data:/home/jovyan/work
+    environment:
+      - JUPYTER_TOKEN=changeme
+    restart: unless-stopped
+
+  code-server:
+    image: codercom/code-server
+    container_name: code-server
+    ports:
+      - "8443:8443"
+    volumes:
+      - code_data:/home/coder/project
+    environment:
+      - PASSWORD=changeme
+    restart: unless-stopped
+
+  qdrant:
+    image: qdrant/qdrant
+    container_name: qdrant
+    ports:
+      - "6333:6333"
+      - "6334:6334"  # gRPC
+    volumes:
+      - qdrant_data:/qdrant/storage
+    restart: unless-stopped
+
+  langchain-server:
+    image: tiangolo/uvicorn-gunicorn-fastapi:python3.11
+    container_name: langchain-server
+    ports:
+      - "8001:80"
+    volumes:
+      - ./langchain_app:/app
+    environment:
+      - MODULE_NAME=main
+    restart: unless-stopped
+
+  llm-api:
+    image: tiangolo/uvicorn-gunicorn-fastapi:python3.11
+    container_name: llm-api
+    ports:
+      - "8002:80"
+    volumes:
+      - ./llm_api:/app
+    environment:
+      - MODULE_NAME=main
+    restart: unless-stopped
+
+volumes:
+  ollama_data:
+  openwebui_data:
+  textgen_data:
+  jupyter_data:
+  code_data:
+  qdrant_data:

--- a/automation_productivity/docker-compose.yml
+++ b/automation_productivity/docker-compose.yml
@@ -1,0 +1,89 @@
+version: "3.8"
+
+services:
+  n8n:
+    image: n8nio/n8n
+    container_name: n8n
+    ports:
+      - "5678:5678"
+    volumes:
+      - n8n_data:/home/node/.n8n
+    restart: unless-stopped
+
+  homebox:
+    image: hay-kot/homebox
+    container_name: homebox
+    ports:
+      - "7745:7745"
+    volumes:
+      - homebox_data:/data
+    restart: unless-stopped
+
+  home-assistant:
+    image: ghcr.io/home-assistant/home-assistant:stable
+    container_name: home-assistant
+    ports:
+      - "8123:8123"
+    volumes:
+      - home_assistant_config:/config
+    restart: unless-stopped
+
+  node-red:
+    image: nodered/node-red
+    container_name: node-red
+    ports:
+      - "1880:1880"
+    volumes:
+      - nodered_data:/data
+    restart: unless-stopped
+
+  tandoor:
+    image: vabene1111/recipes
+    container_name: tandoor
+    ports:
+      - "8081:8080"
+    volumes:
+      - tandoor_static:/opt/recipes/staticfiles
+      - tandoor_media:/opt/recipes/mediafiles
+    restart: unless-stopped
+
+  mealie:
+    image: ghcr.io/mealie-recipes/mealie:v1.0.0
+    container_name: mealie
+    ports:
+      - "9925:9000"
+    volumes:
+      - mealie_data:/app/data
+    restart: unless-stopped
+
+  logseq:
+    image: ghcr.io/realtaboo/logseq:latest
+    container_name: logseq
+    ports:
+      - "3002:3000"
+    volumes:
+      - logseq_data:/logseq
+    restart: unless-stopped
+
+  paperless-ngx:
+    image: ghcr.io/paperless-ngx/paperless-ngx
+    container_name: paperless-ngx
+    ports:
+      - "8005:8000"
+    volumes:
+      - paperless_data:/usr/src/paperless/data
+      - paperless_media:/usr/src/paperless/media
+      - ./paperless/export:/usr/src/paperless/export
+    restart: unless-stopped
+
+volumes:
+  n8n_data:
+  homebox_data:
+  home_assistant_config:
+  nodered_data:
+  tandoor_static:
+  tandoor_media:
+  mealie_data:
+  logseq_data:
+  paperless_data:
+  paperless_media:

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,0 +1,77 @@
+version: "3.8"
+
+services:
+  code-server:
+    image: lscr.io/linuxserver/code-server
+    container_name: code-server-dev
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=UTC
+    volumes:
+      - code_server_data:/config
+      - ./projects:/projects
+    ports:
+      - "8443:8443"
+    restart: unless-stopped
+
+  gitea:
+    image: gitea/gitea:latest
+    container_name: gitea
+    environment:
+      - USER_UID=1000
+      - USER_GID=1000
+    volumes:
+      - gitea_data:/data
+    ports:
+      - "3002:3000"
+      - "222:22"
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:15
+    container_name: postgres
+    environment:
+      - POSTGRES_DB=devdb
+      - POSTGRES_PASSWORD=postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  redis:
+    image: redis:alpine
+    container_name: redis
+    volumes:
+      - redis_data:/data
+    restart: unless-stopped
+
+  minio:
+    image: minio/minio
+    container_name: minio
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=minio
+      - MINIO_ROOT_PASSWORD=minio123
+    volumes:
+      - minio_data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    restart: unless-stopped
+
+  sftpgo:
+    image: drakkan/sftpgo
+    container_name: sftpgo
+    volumes:
+      - sftpgo_data:/var/lib/sftpgo
+    ports:
+      - "2022:2022"
+    restart: unless-stopped
+
+volumes:
+  code_server_data:
+  gitea_data:
+  postgres_data:
+  redis_data:
+  minio_data:
+  sftpgo_data:

--- a/food_health/docker-compose.yml
+++ b/food_health/docker-compose.yml
@@ -1,0 +1,46 @@
+version: "3.8"
+
+services:
+  tandoor:
+    image: vabene1111/recipes
+    container_name: tandoor
+    ports:
+      - "8080:8080"
+    volumes:
+      - tandoor_static:/opt/recipes/staticfiles
+      - tandoor_media:/opt/recipes/mediafiles
+    restart: unless-stopped
+
+  mealie:
+    image: ghcr.io/mealie-recipes/mealie:v1.0.0
+    container_name: mealie
+    ports:
+      - "9090:9000"
+    volumes:
+      - mealie_data:/app/data
+    restart: unless-stopped
+
+  calorie-api:
+    image: tiangolo/uvicorn-gunicorn-fastapi:python3.11
+    container_name: calorie-api
+    volumes:
+      - ./calorie_api:/app
+    command: uvicorn main:app --host 0.0.0.0 --port 8000
+    ports:
+      - "8003:8000"
+    restart: unless-stopped
+
+  grocy:
+    image: linuxserver/grocy
+    container_name: grocy
+    ports:
+      - "9283:80"
+    volumes:
+      - grocy_data:/config
+    restart: unless-stopped
+
+volumes:
+  tandoor_static:
+  tandoor_media:
+  mealie_data:
+  grocy_data:

--- a/home_utility/docker-compose.yml
+++ b/home_utility/docker-compose.yml
@@ -1,0 +1,81 @@
+version: "3.8"
+
+services:
+  openhab:
+    image: openhab/openhab:latest
+    container_name: openhab
+    ports:
+      - "8080:8080"
+    volumes:
+      - openhab_addons:/openhab/addons
+      - openhab_conf:/openhab/conf
+      - openhab_userdata:/openhab/userdata
+    restart: unless-stopped
+
+  grocy:
+    image: linuxserver/grocy
+    container_name: grocy-home
+    ports:
+      - "9284:80"
+    volumes:
+      - grocy_home_data:/config
+    restart: unless-stopped
+
+  immich:
+    image: ghcr.io/immich-app/immich-server:release
+    container_name: immich
+    ports:
+      - "3003:3003"
+    volumes:
+      - immich_library:/usr/src/app/upload
+    restart: unless-stopped
+
+  photoprism:
+    image: photoprism/photoprism
+    container_name: photoprism
+    ports:
+      - "2342:2342"
+    volumes:
+      - photoprism_storage:/photoprism/storage
+      - /path/to/photos:/photoprism/originals
+    restart: unless-stopped
+
+  nextcloud:
+    image: nextcloud
+    container_name: nextcloud
+    ports:
+      - "8082:80"
+    volumes:
+      - nextcloud_data:/var/www/html
+    restart: unless-stopped
+
+  syncthing:
+    image: syncthing/syncthing
+    container_name: syncthing
+    ports:
+      - "8384:8384"
+      - "22000:22000/tcp"
+      - "21027:21027/udp"
+    volumes:
+      - syncthing_config:/var/syncthing
+    restart: unless-stopped
+
+  dashy:
+    image: lissy93/dashy
+    container_name: dashy
+    ports:
+      - "4000:80"
+    volumes:
+      - dashy_data:/app/user-data
+    restart: unless-stopped
+
+volumes:
+  openhab_addons:
+  openhab_conf:
+  openhab_userdata:
+  grocy_home_data:
+  immich_library:
+  photoprism_storage:
+  nextcloud_data:
+  syncthing_config:
+  dashy_data:

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -1,0 +1,102 @@
+version: "3.8"
+
+services:
+  nginx-proxy-manager:
+    image: jc21/nginx-proxy-manager:latest
+    ports:
+      - "80:80"
+      - "81:81"     # NPM admin UI
+      - "443:443"
+    volumes:
+      - npm_data:/data
+      - npm_letsencrypt:/etc/letsencrypt
+    restart: unless-stopped
+
+  portainer:
+    image: portainer/portainer-ce
+    ports:
+      - "9000:9000"
+    volumes:
+      - portainer_data:/data
+      - /var/run/podman/podman.sock:/var/run/docker.sock
+    restart: unless-stopped
+
+  uptime-kuma:
+    image: louislam/uptime-kuma
+    ports:
+      - "3001:3001"
+    volumes:
+      - uptimekuma_data:/app/data
+    restart: unless-stopped
+
+  netdata:
+    image: netdata/netdata
+    ports:
+      - "19999:19999"
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - apparmor:unconfined
+    volumes:
+      - netdata_config:/etc/netdata
+      - netdata_lib:/var/lib/netdata
+      - netdata_cache:/var/cache/netdata
+      - /etc/passwd:/host/etc/passwd:ro
+      - /etc/group:/host/etc/group:ro
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /etc/os-release:/host/etc/os-release:ro
+    environment:
+      - NETDATA_CLAIM_TOKEN=
+      - NETDATA_CLAIM_URL=
+    restart: unless-stopped
+
+  plausible:
+    image: plausible/analytics
+    depends_on:
+      - postgres
+      - clickhouse
+    environment:
+      - BASE_URL=http://localhost:8000
+      - SECRET_KEY=changeme
+      - DISABLE_REGISTRATION=true
+    ports:
+      - "8000:8000"
+    volumes:
+      - plausible_db:/plausible/db
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:14
+    environment:
+      - POSTGRES_PASSWORD=plausiblepass
+      - POSTGRES_USER=plausible
+      - POSTGRES_DB=plausible_db
+    volumes:
+      - plausible_postgres:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:22.6
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
+    restart: unless-stopped
+
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/podman/podman.sock:/var/run/docker.sock
+    command: --cleanup --interval 300
+    restart: unless-stopped
+
+volumes:
+  npm_data:
+  npm_letsencrypt:
+  portainer_data:
+  uptimekuma_data:
+  netdata_config:
+  netdata_lib:
+  netdata_cache:
+  plausible_db:
+  plausible_postgres:
+  clickhouse_data:

--- a/media/docker-compose.yml
+++ b/media/docker-compose.yml
@@ -1,0 +1,110 @@
+version: "3.8"
+
+services:
+  jellyfin:
+    image: jellyfin/jellyfin
+    container_name: jellyfin
+    ports:
+      - "8096:8096"
+    volumes:
+      - jellyfin_config:/config
+      - jellyfin_cache:/cache
+      - /path/to/media:/media
+    restart: unless-stopped
+
+  radarr:
+    image: lscr.io/linuxserver/radarr
+    container_name: radarr
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=UTC
+    volumes:
+      - radarr_config:/config
+      - /path/to/downloads:/downloads
+      - /path/to/movies:/movies
+    ports:
+      - "7878:7878"
+    restart: unless-stopped
+
+  sonarr:
+    image: lscr.io/linuxserver/sonarr
+    container_name: sonarr
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=UTC
+    volumes:
+      - sonarr_config:/config
+      - /path/to/downloads:/downloads
+      - /path/to/tv:/tv
+    ports:
+      - "8989:8989"
+    restart: unless-stopped
+
+  bazarr:
+    image: lscr.io/linuxserver/bazarr
+    container_name: bazarr
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=UTC
+    volumes:
+      - bazarr_config:/config
+      - /path/to/movies:/movies
+      - /path/to/tv:/tv
+    ports:
+      - "6767:6767"
+    restart: unless-stopped
+
+  prowlarr:
+    image: lscr.io/linuxserver/prowlarr
+    container_name: prowlarr
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=UTC
+    volumes:
+      - prowlarr_config:/config
+    ports:
+      - "9696:9696"
+    restart: unless-stopped
+
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent
+    container_name: qbittorrent
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=UTC
+    volumes:
+      - qbittorrent_config:/config
+      - /path/to/downloads:/downloads
+    ports:
+      - "8081:8080"
+      - "6881:6881/udp"
+    restart: unless-stopped
+
+  tdarr:
+    image: ghcr.io/haveagitgat/tdarr
+    container_name: tdarr
+    ports:
+      - "8265:8265"
+      - "8266:8266"
+    volumes:
+      - tdarr_config:/app/configs
+      - tdarr_server:/app/server
+      - tdarr_transcode:/app/transcode_cache
+    restart: unless-stopped
+
+volumes:
+  jellyfin_config:
+  jellyfin_cache:
+  radarr_config:
+  sonarr_config:
+  bazarr_config:
+  prowlarr_config:
+  qbittorrent_config:
+  tdarr_config:
+  tdarr_server:
+  tdarr_transcode:

--- a/networking/docker-compose.yml
+++ b/networking/docker-compose.yml
@@ -1,0 +1,78 @@
+version: "3.8"
+
+services:
+  wireguard:
+    image: linuxserver/wireguard
+    container_name: wireguard
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    ports:
+      - "51820:51820/udp"
+    volumes:
+      - wireguard_config:/config
+    restart: unless-stopped
+
+  tailscale:
+    image: tailscale/tailscale
+    container_name: tailscale
+    network_mode: host
+    privileged: true
+    volumes:
+      - tailscale_var:/var/lib
+      - /dev/net/tun:/dev/net/tun
+    restart: unless-stopped
+
+  pihole:
+    image: pihole/pihole
+    container_name: pihole
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
+      - "8088:80"
+    environment:
+      - TZ=UTC
+    volumes:
+      - pihole_data:/etc/pihole
+      - dnsmasq_data:/etc/dnsmasq.d
+    restart: unless-stopped
+
+  adguard:
+    image: adguard/adguardhome
+    container_name: adguard
+    ports:
+      - "3000:3000"
+      - "3001:3001/tcp"
+      - "3001:3001/udp"
+    volumes:
+      - adguard_data:/opt/adguardhome/work
+      - adguard_conf:/opt/adguardhome/conf
+    restart: unless-stopped
+
+  dnscrypt-proxy:
+    image: jedisct1/dnscrypt-proxy
+    container_name: dnscrypt-proxy
+    ports:
+      - "5053:5053/udp"
+    volumes:
+      - dnscrypt_config:/config
+    restart: unless-stopped
+
+  glances:
+    image: nicolargo/glances
+    container_name: glances
+    ports:
+      - "61208:61208"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    pid: host
+    restart: unless-stopped
+
+volumes:
+  wireguard_config:
+  tailscale_var:
+  pihole_data:
+  dnsmasq_data:
+  adguard_data:
+  adguard_conf:
+  dnscrypt_config:

--- a/setup_services.py
+++ b/setup_services.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Deploy docker compose stacks for each service category."""
+
+import subprocess
+from pathlib import Path
+
+CATEGORIES = [
+    "infrastructure",
+    "ai_llm",
+    "automation_productivity",
+    "networking",
+    "media",
+    "food_health",
+    "development",
+    "home_utility",
+]
+
+
+def run_compose(compose_file: Path) -> None:
+    """Run docker compose up for the given compose file."""
+    subprocess.run(["docker", "compose", "-f", str(compose_file), "up", "-d"], check=True)
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parent
+    for category in CATEGORIES:
+        dir_path = root / category
+        compose_path = dir_path / "docker-compose.yml"
+        if not compose_path.exists():
+            print(f"Missing compose file for {category}, skipping")
+            continue
+        print(f"Deploying {category} stack...")
+        run_compose(compose_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- split services by category under their own folders
- include docker compose files for each category
- add `setup_services.py` to launch every stack
- update documentation with new usage instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cb9275d9883279c6efdae1ec5045d