### PR TITLE
Add compose helper script with password prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@ A home server and Calendar app
 🔧 How to Use It
 Save the file as docker-compose.yml
 
-Run the stack:
+Run the stack using the helper script:
 
---bash
-Copy
-Edit
-podman-compose -p Helen-Infrastructure up -d
---bash
+```bash
+python run_compose.py docker-compose.Helen-Infrastructure.yml -p Helen-Infrastructure
+```
+
+The script will prompt for a password and run `podman compose` with a temporary
+environment file. The file is removed automatically after the command
+completes.
+
 Access Nginx Proxy Manager at:
 
 http://<your-ip>:81

--- a/docker-compose.Helen-AI.yml
+++ b/docker-compose.Helen-AI.yml
@@ -40,7 +40,7 @@ services:
     volumes:
       - jupyter_data:/home/jovyan/work
     environment:
-      - JUPYTER_TOKEN=changeme
+      - JUPYTER_TOKEN=${JUPYTER_TOKEN:-changeme}
     restart: unless-stopped
 
   code-server:
@@ -51,7 +51,7 @@ services:
     volumes:
       - code_data:/home/coder/project
     environment:
-      - PASSWORD=changeme
+      - PASSWORD=${PASSWORD:-changeme}
     restart: unless-stopped
 
   qdrant:

--- a/docker-compose.Helen-Infrastructure.yml
+++ b/docker-compose.Helen-Infrastructure.yml
@@ -69,7 +69,7 @@ services:
   postgres:
     image: postgres:14
     environment:
-      - POSTGRES_PASSWORD=plausiblepass
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-plausiblepass}
       - POSTGRES_USER=plausible
       - POSTGRES_DB=plausible_db
     volumes:

--- a/run_compose.py
+++ b/run_compose.py
@@ -1,0 +1,44 @@
+import argparse
+import getpass
+import os
+import subprocess
+import sys
+import tempfile
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run docker compose with a provided password.")
+    parser.add_argument("compose_file", help="Path to the compose YAML file")
+    parser.add_argument("--project-name", "-p", dest="project", default=None,
+                        help="Compose project name")
+    parser.add_argument("--command", default="up -d",
+                        help="Compose command to run (default 'up -d')")
+    parser.add_argument("--var", dest="var", default="PASSWORD",
+                        help="Environment variable name to set (default PASSWORD)")
+    parser.add_argument("--engine", choices=["docker", "podman"], default="podman",
+                        help="Container engine to use")
+    args = parser.parse_args()
+
+    pw1 = getpass.getpass("Enter password: ")
+    pw2 = getpass.getpass("Confirm password: ")
+    if pw1 != pw2:
+        print("Passwords do not match.")
+        sys.exit(1)
+
+    with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+        tmp.write(f"{args.var}={pw1}\n")
+        env_file = tmp.name
+
+    engine_cmd = [args.engine, "compose", "--env-file", env_file, "-f", args.compose_file]
+    if args.project:
+        engine_cmd += ["-p", args.project]
+    engine_cmd += args.command.split()
+
+    try:
+        subprocess.run(engine_cmd, check=True)
+    finally:
+        os.remove(env_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce `run_compose.py` to run compose files after prompting for a password
- load passwords via temporary env file for compose
- allow compose files to take env vars for passwords
- document helper script usage

## Testing
- `python -m py_compile run_compose.py`


------
https://chatgpt.com/codex/tasks/task_e_688cbd857034832788bc6477859e2553