### PR TITLE
Enable GPU in Ollama compose & add NVIDIA driver script

### DIFF
--- a/ai_llm/docker-compose.yml
+++ b/ai_llm/docker-compose.yml
@@ -8,6 +8,15 @@ services:
       - "11434:11434"
     volumes:
       - ollama_data:/root/.ollama
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     restart: unless-stopped
 
   open-webui:

--- a/install_update_nvidia_drivers.sh
+++ b/install_update_nvidia_drivers.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Install and update NVIDIA drivers on Debian/Ubuntu
+
+set -euo pipefail
+
+# Update package list
+sudo apt-get update
+
+# Install required packages for adding repositories
+sudo apt-get install -y software-properties-common gnupg-curl
+
+# Add the graphics drivers PPA if not already added
+if ! grep -q "graphics-drivers" /etc/apt/sources.list /etc/apt/sources.list.d/* 2>/dev/null; then
+    sudo add-apt-repository -y ppa:graphics-drivers/ppa
+fi
+
+# Refresh package lists after adding the PPA
+sudo apt-get update
+
+# Install recommended NVIDIA driver
+sudo ubuntu-drivers autoinstall
+
+# Reboot prompt
+echo "NVIDIA drivers installed/updated. A reboot may be required."


### PR DESCRIPTION
## Summary
- pass through GPU resources for `ollama` in the `ai_llm` compose stack
- add helper script to install/update NVIDIA drivers

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 manage_services.py --help`


------
https://chatgpt.com/codex/tasks/task_e_688d0962bfdc832796b4e1b52029ed11