### PR TITLE
Add improved home server compose stack

### DIFF
--- a/home-stack.yml
+++ b/home-stack.yml
@@ -1,0 +1,327 @@
+version: "3.9"
+
+# =========
+# NETWORKS
+# =========
+networks:
+  proxy:
+    external: false
+  services:
+    internal: true
+  databases:
+    internal: true
+
+# =========
+# SERVICES
+# =========
+services:
+  # --- Reverse proxy / LAN routing ---
+  traefik:
+    image: traefik:v3.1
+    command:
+      - "--api.dashboard=true"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--certificatesresolvers.le.acme.tlschallenge=true"
+      - "--certificatesresolvers.le.acme.email=admin@example.com"  # replace with your email
+      - "--certificatesresolvers.le.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /srv/containers/traefik/letsencrypt:/letsencrypt
+    networks: [proxy]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.traefik.rule=Host(`traefik.local`)"
+      - "traefik.http.routers.traefik.entrypoints=websecure"
+      - "traefik.http.routers.traefik.tls.certresolver=le"
+      - "traefik.http.routers.traefik.service=api@internal"
+      - "traefik.http.routers.traefik.middlewares=traefik-auth"
+      - "traefik.http.middlewares.traefik-auth.basicauth.users=user:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/"  # user:password
+
+  # --- Datastores (shared) ---
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-stack}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-stackpass}
+      TZ: America/Detroit
+    volumes:
+      - /srv/containers/dbs/postgres:/var/lib/postgresql/data
+    networks: [databases]
+
+  redis:
+    image: redis:7
+    command: ["redis-server","--appendonly","yes"]
+    volumes:
+      - /srv/containers/dbs/redis:/data
+    networks: [databases]
+
+  # Helper to create application databases (runs once and exits)
+  db-init:
+    image: postgres:16
+    depends_on:
+      - postgres
+    networks: [databases]
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD:-stackpass}
+      TZ: America/Detroit
+    entrypoint: ["/bin/bash","-lc"]
+    command: >
+      for db in manyfold immich nextcloud paperless; do
+        psql -h postgres -U ${POSTGRES_USER:-stack} -tc "SELECT 1 FROM pg_database WHERE datname='${db}'" | grep -q 1 \
+        || psql -h postgres -U ${POSTGRES_USER:-stack} -c "CREATE DATABASE ${db};";
+      done
+    restart: "no"
+
+  # --- Apps ---
+  mealie:
+    image: ghcr.io/mealie-recipes/mealie:v1.4.0
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: America/Detroit
+      BASE_URL: http://mealie.local
+    volumes:
+      - /srv/containers/mealie/data:/app/data
+    networks: [services, proxy]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.mealie.rule=Host(`mealie.local`)"
+      - "traefik.http.services.mealie.loadbalancer.server.port=9000"
+
+  grocy:
+    image: lscr.io/linuxserver/grocy:latest
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: America/Detroit
+    volumes:
+      - /srv/containers/grocy/config:/config
+    networks: [services, proxy]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.grocy.rule=Host(`grocy.local`)"
+      - "traefik.http.services.grocy.loadbalancer.server.port=80"
+
+  paperless-ngx:
+    image: ghcr.io/paperless-ngx/paperless-ngx:latest
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: America/Detroit
+      PAPERLESS_URL: http://paperless.local
+      PAPERLESS_REDIS: redis://redis:6379
+      PAPERLESS_FILENAME_FORMAT: "{created_year}/{correspondent}/{title}"
+      PAPERLESS_DBENGINE: postgresql
+      PAPERLESS_DBHOST: postgres
+      PAPERLESS_DBPORT: 5432
+      PAPERLESS_DBNAME: paperless
+      PAPERLESS_DBUSER: ${POSTGRES_USER:-stack}
+      PAPERLESS_DBPASS: ${POSTGRES_PASSWORD:-stackpass}
+    volumes:
+      - /srv/containers/paperless/data:/usr/src/paperless/data
+      - /srv/containers/paperless/media:/usr/src/paperless/media
+      - /srv/containers/paperless/consume:/usr/src/paperless/consume
+    depends_on:
+      - redis
+    networks: [services, databases, proxy]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.paperless.rule=Host(`paperless.local`)"
+      - "traefik.http.services.paperless.loadbalancer.server.port=8000"
+
+  paperless-ai:
+    image: ghcr.io/paperless-ai/paperless-ai:latest
+    environment:
+      PAPERLESS_URL: http://paperless-ngx:8000
+      PAPERLESS_API_TOKEN: ${PAPERLESS_API_TOKEN:-REPLACE_WITH_TOKEN}
+      OPENAI_API_BASE: http://openwebui:8080/v1
+      OPENAI_API_KEY: "sk-noauth"
+      TZ: America/Detroit
+    depends_on:
+      - paperless-ngx
+      - openwebui
+    networks: [services, databases]
+
+  actual:
+    image: actualbudget/actual-server:latest
+    volumes:
+      - /srv/containers/actual/data:/data
+    networks: [services, proxy]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.actual.rule=Host(`budget.local`)"
+      - "traefik.http.services.actual.loadbalancer.server.port=5006"
+
+  homebox:
+    image: ghcr.io/hay-kot/homebox:latest
+    environment:
+      HBOX_LOG_LEVEL: info
+      HBOX_ADMIN_EMAIL: you@example.com
+      HBOX_ADMIN_PASSWORD: ${HBOX_ADMIN_PASSWORD:-change_me}
+    volumes:
+      - /srv/containers/homebox/data:/data
+    networks: [services, proxy]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.homebox.rule=Host(`homebox.local`)"
+      - "traefik.http.services.homebox.loadbalancer.server.port=7745"
+
+  plex:
+    image: lscr.io/linuxserver/plex:latest
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: America/Detroit
+    ports:
+      - "32400:32400/tcp"
+      - "3005:3005/tcp"
+      - "8324:8324/tcp"
+      - "32469:32469/tcp"
+      - "1900:1900/udp"
+      - "32410:32410/udp"
+      - "32412:32412/udp"
+      - "32413:32413/udp"
+      - "32414:32414/udp"
+      - "5353:5353/udp"
+    volumes:
+      - /srv/containers/plex/config:/config
+      - /srv/media/movies:/data/movies
+      - /srv/media/tv:/data/tv
+    networks: [services]
+
+  openwebui:
+    image: ghcr.io/open-webui/open-webui:latest
+    environment:
+      OLLAMA_BASE_URL: http://ollama:11434
+      OPENAI_API_KEYS: "sk-noauth"
+      TZ: America/Detroit
+    volumes:
+      - /srv/containers/openwebui/data:/app/backend/data
+    networks: [services, proxy]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.openwebui.rule=Host(`ai.local`)"
+      - "traefik.http.services.openwebui.loadbalancer.server.port=8080"
+
+  ollama:
+    image: ollama/ollama:latest
+    volumes:
+      - /srv/containers/openwebui/ollama:/root/.ollama
+    networks: [services]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]   # remove if no GPU
+
+  manyfold:
+    image: ghcr.io/manyfold3d/manyfold:latest
+    environment:
+      RAILS_LOG_TO_STDOUT: "true"
+      DATABASE_URL: postgres://${POSTGRES_USER:-stack}:${POSTGRES_PASSWORD:-stackpass}@postgres:5432/manyfold
+      REDIS_URL: redis://redis:6379/0
+      TZ: America/Detroit
+    volumes:
+      - /srv/containers/manyfold/storage:/rails/storage
+      - /srv/media/printing:/models
+    depends_on:
+      - postgres
+      - redis
+    networks: [services, databases, proxy]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.manyfold.rule=Host(`manyfold.local`)"
+      - "traefik.http.services.manyfold.loadbalancer.server.port=3000"
+
+  # Immich (photo/video)
+  immich-server:
+    image: ghcr.io/immich-app/immich-server:release
+    environment:
+      DB_URL: postgres://${POSTGRES_USER:-stack}:${POSTGRES_PASSWORD:-stackpass}@postgres:5432/immich
+      REDIS_HOSTNAME: redis
+      IMMICH_MEDIA_LOCATION: /usr/src/app/upload
+      TZ: America/Detroit
+    volumes:
+      - /srv/media/immich:/usr/src/app/upload
+    depends_on:
+      - postgres
+      - redis
+    networks: [services, databases, proxy]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]   # remove if no GPU
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.immich.rule=Host(`immich.local`)"
+      - "traefik.http.services.immich.loadbalancer.server.port=2283"
+
+  immich-machine-learning:
+    image: ghcr.io/immich-app/immich-machine-learning:release
+    environment:
+      TZ: America/Detroit
+    depends_on:
+      - immich-server
+    networks: [services]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]   # remove if no GPU
+
+  # Nextcloud (Apache)
+  nextcloud:
+    image: nextcloud:stable-apache
+    environment:
+      TZ: America/Detroit
+      POSTGRES_DB: nextcloud
+      POSTGRES_USER: ${POSTGRES_USER:-stack}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-stackpass}
+      POSTGRES_HOST: postgres
+      REDIS_HOST: redis
+      REDIS_HOST_PORT: 6379
+      NEXTCLOUD_TRUSTED_DOMAINS: nextcloud.local
+    volumes:
+      - /srv/containers/nextcloud/html:/var/www/html
+      - /srv/containers/nextcloud/data:/var/www/html/data
+    depends_on:
+      - postgres
+      - redis
+    networks: [services, databases, proxy]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.nextcloud.rule=Host(`nextcloud.local`)"
+      - "traefik.http.services.nextcloud.loadbalancer.server.port=80"
+
+  glance:
+    image: glanceapp/glance:latest
+    volumes:
+      - /srv/containers/glance/glance.yml:/app/glance.yml:ro
+    networks: [services, proxy]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.glance.rule=Host(`home.local`)"
+      - "traefik.http.services.glance.loadbalancer.server.port=8080"
+
+  pinchflat:
+    image: ghcr.io/kepano/pinchflat:latest
+    environment:
+      PUID: "1000"
+      PGID: "1000"
+      TZ: America/Detroit
+    volumes:
+      - /srv/containers/pinchflat/config:/config
+      - /srv/media/youtube:/downloads
+    networks: [services, proxy]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.pinchflat.rule=Host(`pinchflat.local`)"
+      - "traefik.http.services.pinchflat.loadbalancer.server.port=8945"
+


### PR DESCRIPTION
## Summary
- add home-stack.yml with reverse proxy, datastores, and apps
- secure Traefik with HTTPS and basic auth
- configure services for Postgres/Redis and explicit port mappings

## Testing
- `docker compose -f home-stack.yml config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_689f781a506c8327a6aeb4bc37d5e96e